### PR TITLE
fix: Remove `cache:clear` from scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,6 @@
     },
     "scripts": {
         "auto-scripts": {
-            "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "importmap:install": "symfony-cmd",
             "sass:build": "symfony-cmd"


### PR DESCRIPTION
This small patch tries to fix the error experienced when running this template with wasmer.